### PR TITLE
feat: server actions + httpOnly session (fix security review)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,13 @@
 {
-  "name": "nextapp-tmp",
+  "name": "ws-survey",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "nextapp-tmp",
+      "name": "ws-survey",
       "version": "0.1.0",
       "dependencies": {
-        "@supabase/ssr": "^0.10.2",
         "@supabase/supabase-js": "^2.104.0",
         "next": "^16.2.4",
         "react": "19.1.0",
@@ -1072,18 +1071,6 @@
       },
       "engines": {
         "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@supabase/ssr": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@supabase/ssr/-/ssr-0.10.2.tgz",
-      "integrity": "sha512-JFbchN63CXLFHJRNT7udec4/RoD9PmXkSGko3QSO6vUuqGBtSzdmxR7FPfQNr7SuFd65I7Xv46q66ALjEN1cgQ==",
-      "license": "MIT",
-      "dependencies": {
-        "cookie": "^1.0.2"
-      },
-      "peerDependencies": {
-        "@supabase/supabase-js": "^2.102.1"
       }
     },
     "node_modules/@supabase/storage-js": {
@@ -2474,19 +2461,6 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/cookie": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
-      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "lint": "eslint"
   },
   "dependencies": {
-    "@supabase/ssr": "^0.10.2",
     "@supabase/supabase-js": "^2.104.0",
     "next": "^16.2.4",
     "react": "19.1.0",

--- a/src/app/actions/auth.ts
+++ b/src/app/actions/auth.ts
@@ -1,0 +1,37 @@
+'use server';
+
+import { getSupabaseAdmin } from '@/lib/supabase-server';
+import { clearSession, setSessionEmail } from '@/lib/session';
+
+export type LoginResult = { ok: true } | { ok: false; error: string };
+
+export async function loginWithEmail(email: string): Promise<LoginResult> {
+  const normalized = email.trim().toLowerCase();
+  if (!normalized) {
+    return { ok: false, error: 'Zadej svůj email.' };
+  }
+
+  const supabase = getSupabaseAdmin();
+  const { data, error } = await supabase
+    .from('allowed_emails')
+    .select('email')
+    .eq('email', normalized)
+    .maybeSingle();
+
+  if (error) {
+    return { ok: false, error: 'Chyba při ověření: ' + error.message };
+  }
+  if (!data) {
+    return {
+      ok: false,
+      error: 'Tenhle email nemáme na seznamu účastníků. Napiš organizátorovi.',
+    };
+  }
+
+  await setSessionEmail(normalized);
+  return { ok: true };
+}
+
+export async function logout(): Promise<void> {
+  await clearSession();
+}

--- a/src/app/actions/responses.ts
+++ b/src/app/actions/responses.ts
@@ -1,0 +1,55 @@
+'use server';
+
+import { getSupabaseAdmin } from '@/lib/supabase-server';
+import { getSessionEmail } from '@/lib/session';
+
+export type ResponseData = {
+  q1_expectation: string | null;
+  q2_ai_experience: string | null;
+  q3_app_idea: string | null;
+  q4_os: string | null;
+  q5_help_needed: string | null;
+};
+
+export type LoadResult =
+  | { ok: true; response: ResponseData | null }
+  | { ok: false; error: string };
+
+export type SaveResult =
+  | { ok: true; existed: boolean }
+  | { ok: false; error: string };
+
+export async function getMyResponse(): Promise<LoadResult> {
+  const email = await getSessionEmail();
+  if (!email) return { ok: false, error: 'Nejsi přihlášen/a.' };
+
+  const supabase = getSupabaseAdmin();
+  const { data, error } = await supabase
+    .from('responses')
+    .select('q1_expectation, q2_ai_experience, q3_app_idea, q4_os, q5_help_needed')
+    .eq('email', email)
+    .maybeSingle();
+
+  if (error) return { ok: false, error: error.message };
+  return { ok: true, response: data ?? null };
+}
+
+export async function saveResponse(payload: ResponseData): Promise<SaveResult> {
+  const email = await getSessionEmail();
+  if (!email) return { ok: false, error: 'Nejsi přihlášen/a.' };
+
+  const supabase = getSupabaseAdmin();
+
+  const { data: existing } = await supabase
+    .from('responses')
+    .select('id')
+    .eq('email', email)
+    .maybeSingle();
+
+  const { error } = await supabase
+    .from('responses')
+    .upsert({ ...payload, email }, { onConflict: 'email' });
+
+  if (error) return { ok: false, error: error.message };
+  return { ok: true, existed: !!existing };
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,32 +1,9 @@
-'use client';
-
-import { useEffect, useState } from 'react';
+import AuthedView from '@/components/AuthedView';
 import LoginForm from '@/components/LoginForm';
-import SurveyForm from '@/components/SurveyForm';
+import { getSessionEmail } from '@/lib/session';
 
-const STORAGE_KEY = 'ws-survey-email';
-
-export default function Home() {
-  const [email, setEmail] = useState<string | null>(null);
-  const [ready, setReady] = useState(false);
-
-  useEffect(() => {
-    const saved = localStorage.getItem(STORAGE_KEY);
-    if (saved) setEmail(saved);
-    setReady(true);
-  }, []);
-
-  const handleLogin = (loggedEmail: string) => {
-    localStorage.setItem(STORAGE_KEY, loggedEmail);
-    setEmail(loggedEmail);
-  };
-
-  const handleLogout = () => {
-    localStorage.removeItem(STORAGE_KEY);
-    setEmail(null);
-  };
-
-  if (!ready) return null;
+export default async function Home() {
+  const email = await getSessionEmail();
 
   return (
     <div className="min-h-screen bg-white">
@@ -55,30 +32,7 @@ export default function Home() {
 
       {/* Main content */}
       <main className="mx-auto max-w-2xl px-6 py-10 md:py-16">
-        {email ? (
-          <>
-            <div className="mb-6 flex items-center justify-between rounded-xl border border-slate-200 bg-white px-4 py-3 shadow-sm">
-              <div className="flex min-w-0 items-center gap-3">
-                <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-teal-400 to-cyan-500 text-xs font-bold text-white">
-                  {email.charAt(0).toUpperCase()}
-                </div>
-                <div className="min-w-0">
-                  <p className="text-xs text-slate-500">Přihlášen/a jako</p>
-                  <p className="truncate text-sm font-medium text-slate-900">{email}</p>
-                </div>
-              </div>
-              <button
-                onClick={handleLogout}
-                className="ml-3 shrink-0 rounded-lg px-3 py-1.5 text-sm font-medium text-slate-600 hover:bg-slate-100 hover:text-slate-900"
-              >
-                Odhlásit
-              </button>
-            </div>
-            <SurveyForm email={email} />
-          </>
-        ) : (
-          <LoginForm onLogin={handleLogin} />
-        )}
+        {email ? <AuthedView email={email} /> : <LoginForm />}
       </main>
 
       <footer className="border-t border-slate-100 py-8">

--- a/src/components/AuthedView.tsx
+++ b/src/components/AuthedView.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useTransition } from 'react';
+import { logout } from '@/app/actions/auth';
+import SurveyForm from './SurveyForm';
+
+type Props = {
+  email: string;
+};
+
+export default function AuthedView({ email }: Props) {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+
+  const handleLogout = () => {
+    startTransition(async () => {
+      await logout();
+      router.refresh();
+    });
+  };
+
+  return (
+    <>
+      <div className="mb-6 flex items-center justify-between rounded-xl border border-slate-200 bg-white px-4 py-3 shadow-sm">
+        <div className="flex min-w-0 items-center gap-3">
+          <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-teal-400 to-cyan-500 text-xs font-bold text-white">
+            {email.charAt(0).toUpperCase()}
+          </div>
+          <div className="min-w-0">
+            <p className="text-xs text-slate-500">Přihlášen/a jako</p>
+            <p className="truncate text-sm font-medium text-slate-900">{email}</p>
+          </div>
+        </div>
+        <button
+          onClick={handleLogout}
+          disabled={pending}
+          className="ml-3 shrink-0 rounded-lg px-3 py-1.5 text-sm font-medium text-slate-600 hover:bg-slate-100 hover:text-slate-900 disabled:opacity-50"
+        >
+          {pending ? 'Odhlašuji…' : 'Odhlásit'}
+        </button>
+      </div>
+      <SurveyForm />
+    </>
+  );
+}

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -1,42 +1,26 @@
 'use client';
 
-import { useState } from 'react';
-import { createClient } from '@/lib/supabase';
+import { useRouter } from 'next/navigation';
+import { useState, useTransition } from 'react';
+import { loginWithEmail } from '@/app/actions/auth';
 
-type Props = {
-  onLogin: (email: string) => void;
-};
-
-export default function LoginForm({ onLogin }: Props) {
-  const supabase = createClient();
+export default function LoginForm() {
+  const router = useRouter();
   const [email, setEmail] = useState('');
-  const [checking, setChecking] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    const normalized = email.trim().toLowerCase();
-    if (!normalized) {
-      setError('Zadej svůj email.');
-      return;
-    }
-    setChecking(true);
     setError(null);
-    const { data, error: queryError } = await supabase
-      .from('allowed_emails')
-      .select('email')
-      .eq('email', normalized)
-      .maybeSingle();
-    setChecking(false);
-    if (queryError) {
-      setError('Chyba při ověření: ' + queryError.message);
-      return;
-    }
-    if (!data) {
-      setError('Tenhle email nemáme na seznamu účastníků. Napiš organizátorovi.');
-      return;
-    }
-    onLogin(normalized);
+    startTransition(async () => {
+      const result = await loginWithEmail(email);
+      if (!result.ok) {
+        setError(result.error);
+        return;
+      }
+      router.refresh();
+    });
   };
 
   return (
@@ -60,7 +44,7 @@ export default function LoginForm({ onLogin }: Props) {
             onChange={(e) => setEmail(e.target.value)}
             autoComplete="email"
             required
-            disabled={checking}
+            disabled={pending}
             placeholder="jmeno@firma.cz"
             className="w-full rounded-xl border border-slate-300 bg-slate-50 px-4 py-3 text-base text-slate-900 placeholder:text-slate-400 focus:border-teal-500 focus:bg-white focus:outline-none focus:ring-2 focus:ring-teal-500/20 disabled:opacity-50"
           />
@@ -86,10 +70,10 @@ export default function LoginForm({ onLogin }: Props) {
 
         <button
           type="submit"
-          disabled={checking}
+          disabled={pending}
           className="inline-flex w-full items-center justify-center gap-2 rounded-xl bg-gradient-to-r from-teal-500 to-cyan-500 px-4 py-3 font-semibold text-white shadow-sm transition hover:from-teal-600 hover:to-cyan-600 hover:shadow-md focus:outline-none focus:ring-2 focus:ring-teal-500/40 disabled:opacity-60"
         >
-          {checking ? (
+          {pending ? (
             <>
               <span className="h-4 w-4 animate-spin rounded-full border-2 border-white/30 border-t-white" />
               Ověřuji…

--- a/src/components/SurveyForm.tsx
+++ b/src/components/SurveyForm.tsx
@@ -1,11 +1,7 @@
 'use client';
 
-import { useEffect, useState } from 'react';
-import { createClient } from '@/lib/supabase';
-
-type Props = {
-  email: string;
-};
+import { useEffect, useState, useTransition } from 'react';
+import { getMyResponse, saveResponse } from '@/app/actions/responses';
 
 const AI_OPTIONS = [
   { value: 'zkusil', label: 'Něco jsem zkusil/a', hint: 'Občas si něco vyzkouším' },
@@ -22,10 +18,9 @@ const OS_OPTIONS = [
 const inputClass =
   'w-full rounded-xl border border-slate-300 bg-slate-50 px-4 py-3 text-base text-slate-900 placeholder:text-slate-400 focus:border-teal-500 focus:bg-white focus:outline-none focus:ring-2 focus:ring-teal-500/20 disabled:opacity-50';
 
-export default function SurveyForm({ email }: Props) {
-  const supabase = createClient();
+export default function SurveyForm() {
   const [loading, setLoading] = useState(true);
-  const [saving, setSaving] = useState(false);
+  const [saving, startSaving] = useTransition();
   const [message, setMessage] = useState<{ type: 'ok' | 'error'; text: string } | null>(null);
   const [existed, setExisted] = useState(false);
   const [q1, setQ1] = useState('');
@@ -36,20 +31,18 @@ export default function SurveyForm({ email }: Props) {
   const [q5Detail, setQ5Detail] = useState('');
 
   useEffect(() => {
-    const load = async () => {
-      const { data, error } = await supabase
-        .from('responses')
-        .select('*')
-        .eq('email', email)
-        .maybeSingle();
-      if (error) {
-        setMessage({ type: 'error', text: 'Chyba při načítání: ' + error.message });
-      } else if (data) {
-        setQ1(data.q1_expectation ?? '');
-        setQ2(data.q2_ai_experience ?? '');
-        setQ3(data.q3_app_idea ?? '');
-        setQ4(data.q4_os ?? '');
-        const help = data.q5_help_needed ?? '';
+    let cancelled = false;
+    getMyResponse().then((result) => {
+      if (cancelled) return;
+      if (!result.ok) {
+        setMessage({ type: 'error', text: 'Chyba při načítání: ' + result.error });
+      } else if (result.response) {
+        const r = result.response;
+        setQ1(r.q1_expectation ?? '');
+        setQ2(r.q2_ai_experience ?? '');
+        setQ3(r.q3_app_idea ?? '');
+        setQ4(r.q4_os ?? '');
+        const help = r.q5_help_needed ?? '';
         if (help.trim() !== '') {
           setQ5NeedsHelp(true);
           setQ5Detail(help);
@@ -57,38 +50,39 @@ export default function SurveyForm({ email }: Props) {
         setExisted(true);
       }
       setLoading(false);
-    };
-    load();
-  }, [email, supabase]);
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setSaving(true);
-    setMessage(null);
-    const payload = {
-      email,
-      q1_expectation: q1.trim() || null,
-      q2_ai_experience: q2 || null,
-      q3_app_idea: q3.trim() || null,
-      q4_os: q4 || null,
-      q5_help_needed: q5NeedsHelp ? q5Detail.trim() || null : null,
-    };
-    const { error } = await supabase
-      .from('responses')
-      .upsert(payload, { onConflict: 'email' });
-    setSaving(false);
-    if (error) {
-      setMessage({ type: 'error', text: 'Chyba při ukládání: ' + error.message });
-      return;
-    }
-    setMessage({
-      type: 'ok',
-      text: existed ? 'Odpovědi aktualizovány. Díky!' : 'Díky za vyplnění! Odpovědi uloženy.',
     });
-    setExisted(true);
-    if (typeof window !== 'undefined') {
-      window.scrollTo({ top: 0, behavior: 'smooth' });
-    }
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    setMessage(null);
+    startSaving(async () => {
+      const payload = {
+        q1_expectation: q1.trim() || null,
+        q2_ai_experience: q2 || null,
+        q3_app_idea: q3.trim() || null,
+        q4_os: q4 || null,
+        q5_help_needed: q5NeedsHelp ? q5Detail.trim() || null : null,
+      };
+      const result = await saveResponse(payload);
+      if (!result.ok) {
+        setMessage({ type: 'error', text: 'Chyba při ukládání: ' + result.error });
+        return;
+      }
+      setMessage({
+        type: 'ok',
+        text: result.existed
+          ? 'Odpovědi aktualizovány. Díky!'
+          : 'Díky za vyplnění! Odpovědi uloženy.',
+      });
+      setExisted(true);
+      if (typeof window !== 'undefined') {
+        window.scrollTo({ top: 0, behavior: 'smooth' });
+      }
+    });
   };
 
   if (loading) {

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -1,0 +1,39 @@
+import 'server-only';
+import { cookies } from 'next/headers';
+import { getSupabaseAdmin } from './supabase-server';
+
+const COOKIE_NAME = 'ws_survey_email';
+const COOKIE_MAX_AGE = 60 * 60 * 24 * 30;
+
+export async function setSessionEmail(email: string) {
+  const cookieStore = await cookies();
+  cookieStore.set({
+    name: COOKIE_NAME,
+    value: email,
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax',
+    maxAge: COOKIE_MAX_AGE,
+    path: '/',
+  });
+}
+
+export async function clearSession() {
+  const cookieStore = await cookies();
+  cookieStore.delete(COOKIE_NAME);
+}
+
+export async function getSessionEmail(): Promise<string | null> {
+  const cookieStore = await cookies();
+  const cookie = cookieStore.get(COOKIE_NAME);
+  if (!cookie?.value) return null;
+
+  const supabase = getSupabaseAdmin();
+  const { data } = await supabase
+    .from('allowed_emails')
+    .select('email')
+    .eq('email', cookie.value)
+    .maybeSingle();
+
+  return data ? cookie.value : null;
+}

--- a/src/lib/supabase-server.ts
+++ b/src/lib/supabase-server.ts
@@ -1,0 +1,15 @@
+import 'server-only';
+import { createClient } from '@supabase/supabase-js';
+
+export function getSupabaseAdmin() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+    {
+      auth: {
+        persistSession: false,
+        autoRefreshToken: false,
+      },
+    }
+  );
+}

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,8 +1,0 @@
-import { createBrowserClient } from '@supabase/ssr';
-
-export function createClient() {
-  return createBrowserClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!
-  );
-}


### PR DESCRIPTION
## Co se mění a proč

Fix ze [review reportu](https://github.com/jirkasemmler/ws-survey/commit/e3e760d) — před touhle změnou byl anon Supabase klíč v browseru a RLS vypnuté, takže kdokoliv mohl v devtools stáhnout celý whitelist emailů i všechny odpovědi.

## Jak to nově funguje

- `src/lib/supabase-server.ts` — server-only Supabase klient s `SUPABASE_SERVICE_ROLE_KEY`. Import `'server-only'` zabrání náhodnému použití v client komponentě.
- `src/lib/session.ts` — `httpOnly` + `sameSite=lax` cookie. Při každém čtení `getSessionEmail()` se email revaliduje proti `allowed_emails`, takže zmanipulovaná cookie neprojde.
- `src/app/actions/auth.ts` — `loginWithEmail(email)`, `logout()`. Whitelist check běží serverově.
- `src/app/actions/responses.ts` — `getMyResponse()`, `saveResponse(payload)`. Server bere email ze session, klient ho nemůže podstrčit.
- `src/app/page.tsx` — server component, rozhoduje `Login` vs `Authed` podle cookie.
- `src/components/LoginForm`, `SurveyForm` — volají jen server actions, žádný přímý Supabase fetch z browseru.
- Smazán `src/lib/supabase.ts` (browser klient) a balíček `@supabase/ssr` (nevyužit).

## Follow-up (manuální)

Tohle nejde udělat v kódu — musíš v Supabase:

1. Pustit SQL pro zapnutí RLS (viz popis PR / komentář)
2. Přidat `SUPABASE_SERVICE_ROLE_KEY` do Vercel env vars
3. `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` ve Vercelu můžeš smazat — kód ho už nepoužívá

## Jak to otestovat

- **Lokálně:** `npm run dev`, přihlaš se existujícím emailem z whitelistu → otevři devtools → Application → Cookies. Měla by tam být `ws_survey_email` označená **HttpOnly ✓**. V Network tabu **nesmí být** žádný request na `*.supabase.co` z browseru — jen na `/` (server actions jdou přes Next.js POST).
- **Tamper test:** v devtools změň cookie value na `attacker@example.com`, refreshni → měl bys spadnout zpátky na login (revalidace neprošla).
- **Preview deploy z Vercelu:** jakmile přidáš service_role key do Vercel env vars, preview ti vyroste automaticky.
