### PR TITLE
feat: přidat Q6 — preference Claude CLI vs Desktop

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -52,6 +52,7 @@ organizátor přímo v Supabase).
 3. **Máš nápad na appku, co si chceš odnést? Popiš max dvěma větami.** *(freetext)*
 4. **Jaký máš OS?** *(výběr)* — Windows / Mac / Linux
 5. **Budeš chtít pomoct s instalací nějakého toolu?** *(podmíněný freetext)* — ne / ano + popis
+6. **Preferuješ Claude CLI nebo Claude Desktop?** *(výběr)* — CLI / Desktop
 
 ## Datový model
 
@@ -79,6 +80,7 @@ Odpovědi účastníků. Na email je unikátní constraint → 1 účastník = 1
 | `q3_app_idea` | `text` | Q3 — nápad na appku (freetext, max 2 věty) |
 | `q4_os` | `text` | Q4 — `'windows'` / `'mac'` / `'linux'` |
 | `q5_help_needed` | `text` | Q5 — prázdné/NULL = ne, jinak popis instalace |
+| `q6_claude_pref` | `text` | Q6 — `'cli'` / `'desktop'` |
 | `created_at` | `timestamptz` (default now()) | První odeslání |
 | `updated_at` | `timestamptz` (default now()) | Poslední úprava |
 
@@ -103,6 +105,7 @@ create table responses (
   q3_app_idea text,
   q4_os text,
   q5_help_needed text,
+  q6_claude_pref text,
   created_at timestamptz not null default now(),
   updated_at timestamptz not null default now()
 );

--- a/src/app/actions/responses.ts
+++ b/src/app/actions/responses.ts
@@ -9,6 +9,7 @@ export type ResponseData = {
   q3_app_idea: string | null;
   q4_os: string | null;
   q5_help_needed: string | null;
+  q6_claude_pref: string | null;
 };
 
 export type LoadResult =
@@ -26,7 +27,7 @@ export async function getMyResponse(): Promise<LoadResult> {
   const supabase = getSupabaseAdmin();
   const { data, error } = await supabase
     .from('responses')
-    .select('q1_expectation, q2_ai_experience, q3_app_idea, q4_os, q5_help_needed')
+    .select('q1_expectation, q2_ai_experience, q3_app_idea, q4_os, q5_help_needed, q6_claude_pref')
     .eq('email', email)
     .maybeSingle();
 

--- a/src/components/SurveyForm.tsx
+++ b/src/components/SurveyForm.tsx
@@ -15,6 +15,11 @@ const OS_OPTIONS = [
   { value: 'linux', label: 'Linux' },
 ];
 
+const CLAUDE_PREF_OPTIONS = [
+  { value: 'cli', label: 'Claude CLI', hint: 'Claude Code v terminálu' },
+  { value: 'desktop', label: 'Claude Desktop', hint: 'Desktop aplikace' },
+];
+
 const inputClass =
   'w-full rounded-xl border border-slate-300 bg-slate-50 px-4 py-3 text-base text-slate-900 placeholder:text-slate-400 focus:border-teal-500 focus:bg-white focus:outline-none focus:ring-2 focus:ring-teal-500/20 disabled:opacity-50';
 
@@ -29,6 +34,7 @@ export default function SurveyForm() {
   const [q4, setQ4] = useState('');
   const [q5NeedsHelp, setQ5NeedsHelp] = useState(false);
   const [q5Detail, setQ5Detail] = useState('');
+  const [q6, setQ6] = useState('');
 
   useEffect(() => {
     let cancelled = false;
@@ -47,6 +53,7 @@ export default function SurveyForm() {
           setQ5NeedsHelp(true);
           setQ5Detail(help);
         }
+        setQ6(r.q6_claude_pref ?? '');
         setExisted(true);
       }
       setLoading(false);
@@ -66,6 +73,7 @@ export default function SurveyForm() {
         q3_app_idea: q3.trim() || null,
         q4_os: q4 || null,
         q5_help_needed: q5NeedsHelp ? q5Detail.trim() || null : null,
+        q6_claude_pref: q6 || null,
       };
       const result = await saveResponse(payload);
       if (!result.ok) {
@@ -247,6 +255,27 @@ export default function SurveyForm() {
             className={`mt-3 ${inputClass}`}
           />
         )}
+      </Card>
+
+      <Card
+        index={6}
+        title="Preferuješ Claude CLI nebo Claude Desktop?"
+        subtitle="Se kterou variantou chceš pracovat na workshopu"
+        type="volba"
+      >
+        <div className="space-y-2">
+          {CLAUDE_PREF_OPTIONS.map((opt) => (
+            <OptionRow
+              key={opt.value}
+              name="q6"
+              value={opt.value}
+              label={opt.label}
+              hint={opt.hint}
+              checked={q6 === opt.value}
+              onChange={setQ6}
+            />
+          ))}
+        </div>
       </Card>
 
       <div className="sticky bottom-4 z-10 pt-2">


### PR DESCRIPTION
- src/app/actions/responses.ts: přidává q6_claude_pref do ResponseData + select
- src/components/SurveyForm.tsx: nová karta #6 se dvěma volbami (cli / desktop)
- PRD.md: dokumentuje novou otázku ve schématu

DB migrace potřebná v Supabase (viz PR popis):
  alter table responses add column q6_claude_pref text;