### PR TITLE
feat: /start podstránka s clone příkazy

### DIFF
--- a/src/app/start/page.tsx
+++ b/src/app/start/page.tsx
@@ -1,0 +1,113 @@
+import Link from 'next/link';
+import CommandBlock from '@/components/CommandBlock';
+
+const COMMANDS = [
+  'git clone git@github.com:jirkasemmler/prd-vibe-kit.git moje-appka',
+  'cd moje-appka',
+];
+
+export const metadata = {
+  title: 'Start — Workshop dotazník',
+  description: 'Jak začít — naklonuj si workshop kit a začni stavět.',
+};
+
+export default function StartPage() {
+  return (
+    <div className="min-h-screen bg-white">
+      {/* Hero */}
+      <header className="relative overflow-hidden border-b border-slate-100 bg-gradient-to-br from-teal-50 via-white to-cyan-50">
+        <div className="absolute inset-x-0 top-0 h-1 bg-gradient-to-r from-teal-400 via-cyan-400 to-teal-500" />
+        <div className="mx-auto max-w-4xl px-6 py-10 md:py-16">
+          <Link
+            href="/"
+            className="inline-flex items-center gap-1.5 text-xs font-semibold uppercase tracking-widest text-teal-700 hover:text-teal-900"
+          >
+            <svg viewBox="0 0 20 20" fill="currentColor" className="h-3 w-3" aria-hidden>
+              <path
+                fillRule="evenodd"
+                d="M9.707 16.707a1 1 0 0 1-1.414 0l-6-6a1 1 0 0 1 0-1.414l6-6a1 1 0 0 1 1.414 1.414L5.414 9H17a1 1 0 1 1 0 2H5.414l4.293 4.293a1 1 0 0 1 0 1.414Z"
+                clipRule="evenodd"
+              />
+            </svg>
+            Zpět na dotazník
+          </Link>
+          <h1 className="mt-4 text-4xl font-black tracking-tight text-slate-900 md:text-6xl">
+            Začni{' '}
+            <span className="bg-gradient-to-r from-teal-500 to-cyan-500 bg-clip-text text-transparent">
+              stavět
+            </span>
+          </h1>
+          <p className="mt-4 max-w-2xl text-base text-slate-600 md:text-lg">
+            Pusť si terminál, naklonuj workshop kit a vlez do něj.{' '}
+            <strong className="font-semibold text-slate-900">Hotovo za 30 sekund.</strong>
+          </p>
+        </div>
+      </header>
+
+      {/* Main */}
+      <main className="mx-auto max-w-2xl px-6 py-10 md:py-16">
+        {/* Step 1 */}
+        <div className="mb-6">
+          <div className="mb-3 flex items-center gap-3">
+            <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-teal-400 to-cyan-500 text-sm font-bold text-white shadow-sm">
+              1
+            </div>
+            <h2 className="text-lg font-bold text-slate-900 md:text-xl">
+              Spusť tyhle dva příkazy v terminálu
+            </h2>
+          </div>
+          <p className="mb-4 ml-11 text-sm text-slate-600">
+            Najeď myší na jakýkoliv řádek a klikni na ikonku schránky. Nebo zkopíruj
+            oba najednou tlačítkem nahoře.
+          </p>
+        </div>
+
+        <CommandBlock commands={COMMANDS} />
+
+        {/* Step 2 */}
+        <div className="mt-10">
+          <div className="mb-3 flex items-center gap-3">
+            <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-teal-400 to-cyan-500 text-sm font-bold text-white shadow-sm">
+              2
+            </div>
+            <h2 className="text-lg font-bold text-slate-900 md:text-xl">
+              Otevři projekt v Claude Code
+            </h2>
+          </div>
+          <div className="ml-11 rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+            <p className="text-sm text-slate-700 md:text-base">
+              V Claude Code napiš <code className="rounded bg-slate-100 px-1.5 py-0.5 font-mono text-sm text-teal-700">/hack-check</code>{' '}
+              — agent ti ověří prerekvizity a založí ti vlastní GitHub repo.
+            </p>
+          </div>
+        </div>
+
+        {/* Tip */}
+        <div className="mt-10 rounded-2xl border border-cyan-200 bg-gradient-to-br from-cyan-50 to-teal-50 p-5 md:p-6">
+          <div className="flex items-start gap-3">
+            <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-white text-base shadow-sm">
+              💡
+            </div>
+            <div className="min-w-0 flex-1">
+              <h3 className="text-sm font-bold text-cyan-900 md:text-base">
+                Nepoužíváš SSH klíče u GitHubu?
+              </h3>
+              <p className="mt-1 text-sm text-cyan-900/80">
+                Nahraď první příkaz HTTPS variantou:
+              </p>
+              <code className="mt-2 inline-block break-all rounded-md bg-white/70 px-3 py-1.5 font-mono text-xs text-slate-800 md:text-sm">
+                git clone https://github.com/jirkasemmler/prd-vibe-kit.git moje-appka
+              </code>
+            </div>
+          </div>
+        </div>
+      </main>
+
+      <footer className="border-t border-slate-100 py-8">
+        <div className="mx-auto max-w-4xl px-6 text-center text-xs text-slate-400">
+          Hack Your Way 2026 — Product Vibe Coding masterclass
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/src/app/start/page.tsx
+++ b/src/app/start/page.tsx
@@ -45,7 +45,7 @@ export default function StartPage() {
       </header>
 
       {/* Main */}
-      <main className="mx-auto max-w-2xl px-6 py-10 md:py-16">
+      <main className="mx-auto max-w-4xl px-6 py-10 md:py-16">
         {/* Step 1 */}
         <div className="mb-6">
           <div className="mb-3 flex items-center gap-3">

--- a/src/components/CommandBlock.tsx
+++ b/src/components/CommandBlock.tsx
@@ -68,7 +68,9 @@ export default function CommandBlock({ commands }: Props) {
             className="group flex items-center gap-3 rounded-lg px-2 py-2 transition hover:bg-slate-800/60"
           >
             <span className="select-none text-teal-400">$</span>
-            <code className="flex-1 break-all text-slate-100">{cmd}</code>
+            <code className="flex-1 overflow-x-auto whitespace-nowrap text-slate-100">
+              {cmd}
+            </code>
             <button
               onClick={() => copy(cmd, idx)}
               aria-label="Zkopírovat příkaz"

--- a/src/components/CommandBlock.tsx
+++ b/src/components/CommandBlock.tsx
@@ -1,0 +1,118 @@
+'use client';
+
+import { useState } from 'react';
+
+type Props = {
+  commands: string[];
+};
+
+export default function CommandBlock({ commands }: Props) {
+  const [copiedIdx, setCopiedIdx] = useState<number | null>(null);
+  const [copiedAll, setCopiedAll] = useState(false);
+
+  const copy = async (text: string, idx: number) => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopiedIdx(idx);
+      setTimeout(() => setCopiedIdx(null), 1500);
+    } catch {
+      /* clipboard not available */
+    }
+  };
+
+  const copyAll = async () => {
+    try {
+      await navigator.clipboard.writeText(commands.join('\n'));
+      setCopiedAll(true);
+      setTimeout(() => setCopiedAll(false), 1500);
+    } catch {
+      /* clipboard not available */
+    }
+  };
+
+  return (
+    <div className="overflow-hidden rounded-2xl bg-slate-900 shadow-2xl shadow-slate-900/20 ring-1 ring-slate-800/50">
+      {/* Title bar */}
+      <div className="flex items-center justify-between border-b border-slate-800 bg-slate-950/50 px-4 py-3">
+        <div className="flex items-center gap-3">
+          <div className="flex gap-1.5">
+            <span className="h-3 w-3 rounded-full bg-red-500/80" />
+            <span className="h-3 w-3 rounded-full bg-yellow-500/80" />
+            <span className="h-3 w-3 rounded-full bg-green-500/80" />
+          </div>
+          <span className="hidden font-mono text-xs text-slate-400 sm:inline">terminál</span>
+        </div>
+        <button
+          onClick={copyAll}
+          className="inline-flex items-center gap-1.5 rounded-md border border-slate-700 bg-slate-800/60 px-2.5 py-1 text-xs font-medium text-slate-300 transition hover:border-teal-500/50 hover:bg-slate-800 hover:text-teal-300"
+        >
+          {copiedAll ? (
+            <>
+              <CheckIcon />
+              Zkopírováno
+            </>
+          ) : (
+            <>
+              <ClipboardIcon />
+              Zkopírovat vše
+            </>
+          )}
+        </button>
+      </div>
+
+      {/* Body */}
+      <div className="space-y-1 p-4 font-mono text-sm md:text-base">
+        {commands.map((cmd, idx) => (
+          <div
+            key={idx}
+            className="group flex items-center gap-3 rounded-lg px-2 py-2 transition hover:bg-slate-800/60"
+          >
+            <span className="select-none text-teal-400">$</span>
+            <code className="flex-1 break-all text-slate-100">{cmd}</code>
+            <button
+              onClick={() => copy(cmd, idx)}
+              aria-label="Zkopírovat příkaz"
+              className="shrink-0 rounded-md p-1.5 text-slate-500 opacity-0 transition hover:bg-slate-700 hover:text-teal-300 focus:opacity-100 group-hover:opacity-100"
+            >
+              {copiedIdx === idx ? <CheckIcon className="text-teal-400" /> : <ClipboardIcon />}
+            </button>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function ClipboardIcon({ className = '' }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 20 20"
+      fill="currentColor"
+      className={`h-4 w-4 ${className}`}
+      aria-hidden
+    >
+      <path
+        fillRule="evenodd"
+        d="M7.5 3.75A1.5 1.5 0 0 1 9 2.25h2A1.5 1.5 0 0 1 12.5 3.75v.75h2.25A2.25 2.25 0 0 1 17 6.75v9.5A2.25 2.25 0 0 1 14.75 18.5H5.25A2.25 2.25 0 0 1 3 16.25v-9.5A2.25 2.25 0 0 1 5.25 4.5H7.5v-.75ZM9 3.75h2v1.5H9v-1.5Z"
+        clipRule="evenodd"
+      />
+    </svg>
+  );
+}
+
+function CheckIcon({ className = '' }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 20 20"
+      fill="currentColor"
+      className={`h-4 w-4 ${className}`}
+      aria-hidden
+    >
+      <path
+        fillRule="evenodd"
+        d="M16.704 4.153a.75.75 0 0 1 .143 1.052l-8 10.5a.75.75 0 0 1-1.127.075l-4.5-4.5a.75.75 0 0 1 1.06-1.06l3.894 3.893 7.48-9.817a.75.75 0 0 1 1.05-.143Z"
+        clipRule="evenodd"
+      />
+    </svg>
+  );
+}


### PR DESCRIPTION
## Co se přidává

Nová statická podstránka **`/start`** pro účastníky workshopu — naváděč, jak začít.

## Obsah

1. **Hero** ve stejném teal/cyan stylu jako hlavní stránka, s šipkou zpět na dotazník.
2. **Krok 1** — terminálový blok (macOS-style: 3 barevné tečky, dark slate pozadí, teal `$` prompt) s dvěma příkazy:
   ```
   git clone git@github.com:jirkasemmler/prd-vibe-kit.git moje-appka
   cd moje-appka
   ```
   Hover na řádek odhalí copy ikonku, navíc `Zkopírovat vše` tlačítko nahoře. Po kliknutí krátká `✓ Zkopírováno` zpětná vazba.
3. **Krok 2** — instrukce napsat v Claude Code `/hack-check`.
4. **💡 Tip box** s HTTPS variantou pro lidi bez SSH klíčů.

## Soubory

- `src/app/start/page.tsx` — stránka (server component, statická)
- `src/components/CommandBlock.tsx` — copy-to-clipboard terminálový blok (client)

## Test

- `npm run dev` → http://localhost:3000/start
- Otestuj copy buttony (per-line + copy all) — měla by být `✓ Zkopírováno` flash hláška
- Vyzkoušej responzivně (mobil — `terminál` label se schová, copy buttony fungují bez hoveru)
