### PR TITLE
style: rozšířit /start a zabránit zalamování příkazů

### DIFF
--- a/src/app/start/page.tsx
+++ b/src/app/start/page.tsx
@@ -45,7 +45,7 @@ export default function StartPage() {
       </header>
 
       {/* Main */}
-      <main className="mx-auto max-w-2xl px-6 py-10 md:py-16">
+      <main className="mx-auto max-w-4xl px-6 py-10 md:py-16">
         {/* Step 1 */}
         <div className="mb-6">
           <div className="mb-3 flex items-center gap-3">

--- a/src/components/CommandBlock.tsx
+++ b/src/components/CommandBlock.tsx
@@ -68,7 +68,9 @@ export default function CommandBlock({ commands }: Props) {
             className="group flex items-center gap-3 rounded-lg px-2 py-2 transition hover:bg-slate-800/60"
           >
             <span className="select-none text-teal-400">$</span>
-            <code className="flex-1 break-all text-slate-100">{cmd}</code>
+            <code className="flex-1 overflow-x-auto whitespace-nowrap text-slate-100">
+              {cmd}
+            </code>
             <button
               onClick={() => copy(cmd, idx)}
               aria-label="Zkopírovat příkaz"


### PR DESCRIPTION
## Co se mění

Terminálový blok na `/start` se zalamoval na úzkém kontejneru. Tahle změna:

- **`src/app/start/page.tsx`** — main container `max-w-2xl` → `max-w-4xl` (672px → 896px)
- **`src/components/CommandBlock.tsx`** — kód řádky: `break-all` → `overflow-x-auto whitespace-nowrap`. Dlouhé příkazy zůstanou na jednom řádku, na úzkém okně se dají horizontálně posunout.

## Test

`npm run dev` → http://localhost:3000/start

`git clone git@github.com:jirkasemmler/prd-vibe-kit.git moje-appka` se musí vejít na jeden řádek na desktopu.